### PR TITLE
[fix] Avoid duplicated Disbursements creation

### DIFF
--- a/app/models/disbursement.rb
+++ b/app/models/disbursement.rb
@@ -7,4 +7,5 @@ class Disbursement < ApplicationRecord
 
   validates :applied_fee, presence: true, inclusion: { in: AVAILABLE_FEES }
   validates :total, presence: true
+  validates :related_week, presence: true
 end

--- a/app/modules/calculators/last_week_disbursement.rb
+++ b/app/modules/calculators/last_week_disbursement.rb
@@ -6,10 +6,13 @@ module Calculators
       merchants.each do |merchant|
         total = merchant.orders.sum(:amount)
 
+        next if ::Disbursement.where(merchant:, related_week: start_date.to_date.cweek).any?
+
         ::Disbursement.create!(
           merchant:,
           applied_fee: fee_value(total),
-          total: (fee_value(total) * total)
+          total: (fee_value(total) * total),
+          related_week: start_date.to_date.cweek
         )
       end
     end

--- a/db/migrate/20220829150017_add_related_week_to_disbursement.rb
+++ b/db/migrate/20220829150017_add_related_week_to_disbursement.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddRelatedWeekToDisbursement < ActiveRecord::Migration[7.0]
+  def change
+    add_column :disbursements, :related_week, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_29_002453) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_29_150017) do
   create_table "delayed_jobs", force: :cascade do |t|
     t.integer "priority", default: 0, null: false
     t.integer "attempts", default: 0, null: false
@@ -32,6 +32,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_29_002453) do
     t.decimal "total", default: "0.0", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "related_week", default: 0, null: false
     t.index ["merchant_id"], name: "index_disbursements_on_merchant_id"
   end
 

--- a/spec/models/disbursement_spec.rb
+++ b/spec/models/disbursement_spec.rb
@@ -12,5 +12,6 @@ RSpec.describe Disbursement, type: :model do
     it { is_expected.to validate_inclusion_of(:applied_fee).in_array(described_class::AVAILABLE_FEES) }
 
     it { is_expected.to validate_presence_of(:total) }
+    it { is_expected.to validate_presence_of(:related_week) }
   end
 end


### PR DESCRIPTION
This PR adds a new column to `Disbursement` model to store the calendar week that the disbursement relates.
It also avoids creating Disbursements for the merchant if there's already a disbursement for that merchant in the specified calendar week.